### PR TITLE
fix: Handle decryption with invalid password

### DIFF
--- a/tests/PatrimonioTech.Infra.Tests/Credentials/v1/Pbkdf2KeyDerivationTests.cs
+++ b/tests/PatrimonioTech.Infra.Tests/Credentials/v1/Pbkdf2KeyDerivationTests.cs
@@ -29,7 +29,7 @@ public class Pbkdf2KeyDerivationTests(ITestOutputHelper outputHelper)
             select _keyDerivation.CreateKey(p, keySize, iterations);
 
         // Assert
-        (string? salt, string? encryptedKey) = result.Should().Succeed().And.Subject.Value;
+        var (salt, encryptedKey) = result.Should().Succeed().And.Subject.Value;
 
         salt.Should().NotBeEmpty();
         encryptedKey.Should().NotBeEmpty();
@@ -43,7 +43,7 @@ public class Pbkdf2KeyDerivationTests(ITestOutputHelper outputHelper)
     public void TryGetKey_WithValidInput_ReturnsKey(string password, int keySize, int iterations)
     {
         // Arrange
-        (string salt, string encryptedKey) = (from p in Password.Create(password)
+        var (salt, encryptedKey) = (from p in Password.Create(password)
                 select _keyDerivation.CreateKey(p, keySize, iterations))
             .Value;
 
@@ -82,7 +82,7 @@ public class Pbkdf2KeyDerivationTests(ITestOutputHelper outputHelper)
     public void TryGetKey_WithInvalidEncryptedKey_ReturnsFailure(string password, int keySize, int iterations)
     {
         // Arrange
-        (string salt, string encryptedKey) = (from p in Password.Create(password)
+        var (salt, encryptedKey) = (from p in Password.Create(password)
                 select _keyDerivation.CreateKey(p, keySize, iterations))
             .Value;
 
@@ -99,7 +99,7 @@ public class Pbkdf2KeyDerivationTests(ITestOutputHelper outputHelper)
     public void TryGetKey_WithInvalidPassword_ReturnsFailure(string password, int keySize, int iterations)
     {
         // Arrange
-        (string salt, string encryptedKey) = (from p in Password.Create(password)
+        var (salt, encryptedKey) = (from p in Password.Create(password)
                 select _keyDerivation.CreateKey(p, keySize, iterations))
             .Value;
 


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed
- Tests with invalid password fails randomly

## Details on the issue fix or feature implementation
- Handle when decryption do not fit expected length

## Confirm the following
- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build