### PR TITLE
feat(domain): refactor credential storage to use PHC string format

### DIFF
--- a/.sdd/specs/add-user/tasks.md
+++ b/.sdd/specs/add-user/tasks.md
@@ -32,8 +32,8 @@
   - Add or verify unit tests for each short-circuit path and the success path
   - _Requirements: 5.1, 5.2, 6.1, 6.2, 7.1, 7.2_
 
-- [ ] 3. Verify Infra layer implementations
-- [ ] 3.1 (P) Verify Pbkdf2KeyDerivation and PhcString round-trip
+- [x] 3. Verify Infra layer implementations
+- [x] 3.1 (P) Verify Pbkdf2KeyDerivation and PhcString round-trip
   - Confirm `CreateKey` generates a valid `IPhcString` and returns `Ok`
   - Confirm `TryGetKey` with the correct password and hash returns the database key successfully
   - Confirm `TryGetKey` with an incorrect password returns an error
@@ -41,14 +41,14 @@
   - Add or verify integration tests for the full round-trip
   - _Requirements: 5.1, 5.2_
 
-- [ ] 3.2 (P) Verify FileUserCredentialRepository
+- [x] 3.2 (P) Verify FileUserCredentialRepository
   - Confirm `Add` persists a credential to the JSON file and can be retrieved via `GetAll`
   - Confirm `Add` with a duplicate name (case-insensitive) returns `NameAlreadyExists`
   - Verify atomic write strategy (temp file + `File.Replace`) is implemented
   - Add or verify integration tests for first add, duplicate add, and round-trip read
   - _Requirements: 7.1, 7.2_
 
-- [ ] 3.3 (P) Verify LiteDbDatabaseAdmin
+- [x] 3.3 (P) Verify LiteDbDatabaseAdmin
   - Confirm `CreateDatabase` creates an encrypted LiteDB file at the path derived from the database GUID
   - Confirm the database is accessible with the provided key
   - Add or verify an integration test for database creation

--- a/src/PatrimonioTech.App/Credentials/v1/AddUser/CredentialAddUserRequest.cs
+++ b/src/PatrimonioTech.App/Credentials/v1/AddUser/CredentialAddUserRequest.cs
@@ -1,9 +1,3 @@
-﻿using PatrimonioTech.Domain.Credentials;
-
 namespace PatrimonioTech.App.Credentials.v1.AddUser;
 
-public sealed record CredentialAddUserRequest(
-    string Name,
-    string Password,
-    int KeySize = UserCredential.DefaultKeySize,
-    int Iterations = UserCredential.DefaultIterations);
+public sealed record CredentialAddUserRequest(string Name, string Password);

--- a/src/PatrimonioTech.App/Credentials/v1/AddUser/CredentialAddUserUseCase.cs
+++ b/src/PatrimonioTech.App/Credentials/v1/AddUser/CredentialAddUserUseCase.cs
@@ -1,4 +1,4 @@
-﻿using PatrimonioTech.App.Database;
+using PatrimonioTech.App.Database;
 using PatrimonioTech.Domain.Credentials;
 using PatrimonioTech.Domain.Credentials.Actions.AddUser;
 using PatrimonioTech.Domain.Credentials.Services;
@@ -18,12 +18,12 @@ public sealed class CredentialAddUserUseCase(
         CancellationToken cancellationToken)
     {
         return from scnRes in addUserScenario
-                .Execute(new AddUserCredential(request.Name, request.Password, request.KeySize, request.Iterations))
+                .Execute(new AddUserCredential(request.Name, request.Password))
                 .MapErr(CredentialAddUserError.BusinessError.λ)
                 .ToTask()
             let model = UserCredential.Create(scnRes)
             from key in keyDerivation
-                .TryGetKey(request.Password, model.Salt, model.Key, model.KeySize, model.Iterations)
+                .TryGetKey(request.Password, model.PasswordHash)
                 .MapErr(CredentialAddUserError.CryptographyError.λ)
                 .ToTask()
             from db in databaseAdmin.CreateDatabase(model.Database, key)

--- a/src/PatrimonioTech.App/Credentials/v1/GetUserInfo/CredentialGetUserInfoUseCase.cs
+++ b/src/PatrimonioTech.App/Credentials/v1/GetUserInfo/CredentialGetUserInfoUseCase.cs
@@ -1,4 +1,4 @@
-﻿using FxKit.Extensions;
+using FxKit.Extensions;
 using PatrimonioTech.Domain.Credentials.Services;
 
 namespace PatrimonioTech.App.Credentials.v1.GetUserInfo;
@@ -21,12 +21,7 @@ public sealed class CredentialGetUserInfoUseCase(
                 .OkOrElse(CredentialGetUserInfoError.UserNotFound.Of)
                 .ToTask()
             from password in keyDerivation
-                .TryGetKey(
-                    password: request.Password,
-                    salt: foundUser.Salt,
-                    encryptedKey: foundUser.Key,
-                    keySize: foundUser.KeySize,
-                    iterations: foundUser.Iterations)
+                .TryGetKey(request.Password, foundUser.PasswordHash)
                 .MapErr(CredentialGetUserInfoError.CryptographyError.Of)
                 .ToTask()
             select new CredentialGetUserInfoResponse(

--- a/src/PatrimonioTech.Domain/Credentials/Actions/AddUser/AddUserCredential.cs
+++ b/src/PatrimonioTech.Domain/Credentials/Actions/AddUser/AddUserCredential.cs
@@ -1,7 +1,3 @@
-﻿namespace PatrimonioTech.Domain.Credentials.Actions.AddUser;
+namespace PatrimonioTech.Domain.Credentials.Actions.AddUser;
 
-public sealed record AddUserCredential(
-    string Name,
-    string Password,
-    int KeySize,
-    int Iterations);
+public sealed record AddUserCredential(string Name, string Password);

--- a/src/PatrimonioTech.Domain/Credentials/Actions/AddUser/AddUserCredentialError.cs
+++ b/src/PatrimonioTech.Domain/Credentials/Actions/AddUser/AddUserCredentialError.cs
@@ -1,4 +1,5 @@
-﻿using FxKit.CompilerServices;
+using FxKit.CompilerServices;
+using PatrimonioTech.Domain.Credentials.Services;
 
 namespace PatrimonioTech.Domain.Credentials.Actions.AddUser;
 
@@ -9,11 +10,5 @@ public partial record AddUserCredentialError
 
     partial record NameTooShort;
 
-    partial record KeySizeTooLow;
-
-    partial record KeySizeTooHigh;
-
-    partial record IterationsTooLow;
-
-    partial record IterationsTooHigh;
+    partial record KeyDerivationFailed(CryptographyError Error);
 }

--- a/src/PatrimonioTech.Domain/Credentials/Actions/AddUser/AddUserScenario.cs
+++ b/src/PatrimonioTech.Domain/Credentials/Actions/AddUser/AddUserScenario.cs
@@ -1,4 +1,4 @@
-﻿using FxKit.Parsers;
+using FxKit.Parsers;
 using PatrimonioTech.Domain.Credentials.Services;
 
 namespace PatrimonioTech.Domain.Credentials.Actions.AddUser;
@@ -7,10 +7,6 @@ namespace PatrimonioTech.Domain.Credentials.Actions.AddUser;
 public sealed class AddUserScenario(IKeyDerivation keyDerivation) : IAddUserScenario
 {
     public const int NameMinLength = 3;
-    private const int KeySizeMinimum = 128;
-    private const int KeySizeMaximum = 4096;
-    private const int IterationsMinimum = 1000;
-    private const int IterationsMaximum = 100_000_000;
 
     public Result<UserCredentialAdded, AddUserCredentialError> Execute(AddUserCredential command)
     {
@@ -19,14 +15,9 @@ public sealed class AddUserScenario(IKeyDerivation keyDerivation) : IAddUserScen
                 .OkOrElse(AddUserCredentialError.NameTooShort.Of)
             from password in Password.Create(command.Password)
                 .MapErr(AddUserCredentialError.InvalidPassword.Of)
-            from keySize in command.KeySize
-                .Ensure(v => v >= KeySizeMinimum, AddUserCredentialError.KeySizeTooLow.Of)
-                .Ensure(v => v <= KeySizeMaximum, AddUserCredentialError.KeySizeTooHigh.Of)
-            from iterations in command.Iterations
-                .Ensure(v => v >= IterationsMinimum, AddUserCredentialError.IterationsTooLow.Of)
-                .Ensure(v => v <= IterationsMaximum, AddUserCredentialError.IterationsTooHigh.Of)
-            let key = keyDerivation.CreateKey(password, keySize, iterations)
+            from phcString in keyDerivation.CreateKey(password)
+                .MapErr(AddUserCredentialError.KeyDerivationFailed.Of)
             let dbId = Guid.NewGuid()
-            select new UserCredentialAdded(name, key.Salt, key.EncryptedKey, dbId, keySize, iterations);
+            select new UserCredentialAdded(name, phcString.Value, dbId);
     }
 }

--- a/src/PatrimonioTech.Domain/Credentials/Actions/AddUser/UserCredentialAdded.cs
+++ b/src/PatrimonioTech.Domain/Credentials/Actions/AddUser/UserCredentialAdded.cs
@@ -1,9 +1,3 @@
-﻿namespace PatrimonioTech.Domain.Credentials.Actions.AddUser;
+namespace PatrimonioTech.Domain.Credentials.Actions.AddUser;
 
-public sealed record UserCredentialAdded(
-    string Name,
-    string Salt,
-    string Key,
-    Guid Database,
-    int KeySize,
-    int Iterations);
+public sealed record UserCredentialAdded(string Name, string PasswordHash, Guid Database);

--- a/src/PatrimonioTech.Domain/Credentials/Services/CryptographyError.cs
+++ b/src/PatrimonioTech.Domain/Credentials/Services/CryptographyError.cs
@@ -2,5 +2,6 @@ namespace PatrimonioTech.Domain.Credentials.Services;
 
 public enum CryptographyError
 {
-    Failed = 1,
+    KeyDerivationFailed = 1,
+    EncryptionFailed = 2,
 }

--- a/src/PatrimonioTech.Domain/Credentials/Services/CryptographyError.cs
+++ b/src/PatrimonioTech.Domain/Credentials/Services/CryptographyError.cs
@@ -1,6 +1,6 @@
 namespace PatrimonioTech.Domain.Credentials.Services;
 
-public enum GetKeyError
+public enum CryptographyError
 {
-    InvalidPassword = 1,
+    Failed = 1,
 }

--- a/src/PatrimonioTech.Domain/Credentials/Services/GetKeyError.cs
+++ b/src/PatrimonioTech.Domain/Credentials/Services/GetKeyError.cs
@@ -3,4 +3,5 @@ namespace PatrimonioTech.Domain.Credentials.Services;
 public enum GetKeyError
 {
     InvalidPassword = 1,
+    InvalidHash = 2,
 }

--- a/src/PatrimonioTech.Domain/Credentials/Services/IKeyDerivation.cs
+++ b/src/PatrimonioTech.Domain/Credentials/Services/IKeyDerivation.cs
@@ -1,8 +1,8 @@
-﻿namespace PatrimonioTech.Domain.Credentials.Services;
+namespace PatrimonioTech.Domain.Credentials.Services;
 
 public interface IKeyDerivation
 {
-    CreateKeyResult CreateKey(Password password, int keySize, int iterations);
+    Result<IPhcString, CryptographyError> CreateKey(Password password);
 
-    Result<string, GetKeyError> TryGetKey(string password, string salt, string encryptedKey, int keySize, int iterations);
+    Result<string, GetKeyError> TryGetKey(string password, string passwordHash);
 }

--- a/src/PatrimonioTech.Domain/Credentials/Services/IPhcString.cs
+++ b/src/PatrimonioTech.Domain/Credentials/Services/IPhcString.cs
@@ -1,6 +1,6 @@
 namespace PatrimonioTech.Domain.Credentials.Services;
 
-public enum GetKeyError
+public interface IPhcString
 {
-    InvalidPassword = 1,
+    string Value { get; }
 }

--- a/src/PatrimonioTech.Domain/Credentials/UserCredential.cs
+++ b/src/PatrimonioTech.Domain/Credentials/UserCredential.cs
@@ -1,35 +1,20 @@
-﻿using PatrimonioTech.Domain.Credentials.Actions.AddUser;
+using PatrimonioTech.Domain.Credentials.Actions.AddUser;
 
 namespace PatrimonioTech.Domain.Credentials;
 
 public sealed class UserCredential
 {
-    public const int DefaultKeySize = 512;
-    public const int DefaultIterations = 100_000;
-
-    private UserCredential(
-        string name,
-        string salt,
-        string key,
-        Guid database,
-        int keySize = DefaultKeySize,
-        int iterations = DefaultIterations)
+    private UserCredential(string name, string passwordHash, Guid database)
     {
         Name = name;
-        Salt = salt;
-        Key = key;
+        PasswordHash = passwordHash;
         Database = database;
-        KeySize = keySize;
-        Iterations = iterations;
     }
 
     public string Name { get; }
-    public string Salt { get; }
-    public string Key { get; }
+    public string PasswordHash { get; }
     public Guid Database { get; }
-    public int KeySize { get; }
-    public int Iterations { get; }
 
     public static UserCredential Create(UserCredentialAdded added) =>
-        new(added.Name, added.Salt, added.Key, added.Database, added.KeySize, added.Iterations);
+        new(added.Name, added.PasswordHash, added.Database);
 }

--- a/src/PatrimonioTech.Infra/Credentials/Services/FileUserCredentialRepository.cs
+++ b/src/PatrimonioTech.Infra/Credentials/Services/FileUserCredentialRepository.cs
@@ -96,16 +96,34 @@ public sealed partial class FileUserCredentialRepository : IUserCredentialReposi
 
     private async Task Write(List<UserCredentialModel> data, CancellationToken cancellationToken)
     {
-        var fileStream = new FileStream(_configFile, FileMode.Create, FileAccess.Write);
-        await using (fileStream.ConfigureAwait(false))
+        var tempFile = Path.Combine(_appData, $"{Path.GetRandomFileName()}.tmp");
+        try
         {
-            await JsonSerializer
-                .SerializeAsync(fileStream, data, _jsonOptions, cancellationToken)
-                .ConfigureAwait(false);
+            var fileStream = new FileStream(tempFile, FileMode.Create, FileAccess.Write);
+            await using (fileStream.ConfigureAwait(false))
+            {
+                await JsonSerializer
+                    .SerializeAsync(fileStream, data, _jsonOptions, cancellationToken)
+                    .ConfigureAwait(false);
 
-            await fileStream
-                .FlushAsync(cancellationToken)
-                .ConfigureAwait(false);
+                await fileStream
+                    .FlushAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (File.Exists(_configFile))
+            {
+                File.Replace(tempFile, _configFile, destinationBackupFileName: null);
+            }
+            else
+            {
+                File.Move(tempFile, _configFile);
+            }
+        }
+        catch when (File.Exists(tempFile))
+        {
+            File.Delete(tempFile);
+            throw;
         }
     }
 

--- a/src/PatrimonioTech.Infra/Credentials/Services/FileUserCredentialRepository.cs
+++ b/src/PatrimonioTech.Infra/Credentials/Services/FileUserCredentialRepository.cs
@@ -113,7 +113,7 @@ public sealed partial class FileUserCredentialRepository : IUserCredentialReposi
 
             if (File.Exists(_configFile))
             {
-                File.Replace(tempFile, _configFile, destinationBackupFileName: null);
+                File.Replace(tempFile, _configFile, destinationBackupFileName: _configFile + ".bak");
             }
             else
             {

--- a/src/PatrimonioTech.Infra/Credentials/Services/IPbkdf2PhcStringParser.cs
+++ b/src/PatrimonioTech.Infra/Credentials/Services/IPbkdf2PhcStringParser.cs
@@ -1,0 +1,10 @@
+using PatrimonioTech.Domain.Credentials.Services;
+
+namespace PatrimonioTech.Infra.Credentials.Services;
+
+public interface IPbkdf2PhcStringParser
+{
+    Pbkdf2PhcString Create(string salt, string encryptedKey, int iterations, int keyLengthBits);
+
+    Result<Pbkdf2PhcString, GetKeyError> Parse(ReadOnlySpan<char> value);
+}

--- a/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2KeyDerivation.cs
+++ b/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2KeyDerivation.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
 using Microsoft.Extensions.Logging;
 using PatrimonioTech.Domain.Credentials;
 using PatrimonioTech.Domain.Credentials.Services;
@@ -8,6 +8,8 @@ namespace PatrimonioTech.Infra.Credentials.Services;
 public sealed partial class Pbkdf2KeyDerivation : IKeyDerivation
 {
     private const int BitsPerByte = 8;
+    private const int DefaultKeyLengthBits = 512;
+    private const int DefaultIterations = 100_000;
     private const int AesMaxKeySize = 256;
     private const int AesMaxIvSize = 128;
     private static readonly HashAlgorithmName s_hashAlgorithmName = HashAlgorithmName.SHA512;
@@ -19,51 +21,63 @@ public sealed partial class Pbkdf2KeyDerivation : IKeyDerivation
         _logger = logger;
     }
 
-    public CreateKeyResult CreateKey(Password password, int keySize, int iterations)
+    public Result<IPhcString, CryptographyError> CreateKey(Password password)
     {
-        Span<byte> binarySalt = stackalloc byte[keySize / BitsPerByte];
-        RandomNumberGenerator.Fill(binarySalt);
+        try
+        {
+            var keyLengthBytes = DefaultKeyLengthBits / BitsPerByte;
 
-        Span<byte> binaryKey = stackalloc byte[keySize / BitsPerByte];
-        RandomNumberGenerator.Fill(binaryKey);
+            Span<byte> binarySalt = stackalloc byte[keyLengthBytes];
+            RandomNumberGenerator.Fill(binarySalt);
 
-        var binaryHash = new byte[AesMaxKeySize / BitsPerByte];
-        Rfc2898DeriveBytes.Pbkdf2(password.Value, binarySalt, binaryHash, iterations, s_hashAlgorithmName);
+            Span<byte> binaryKey = stackalloc byte[keyLengthBytes];
+            RandomNumberGenerator.Fill(binaryKey);
 
-        Span<byte> encrypted = stackalloc byte[keySize];
+            var binaryHash = new byte[AesMaxKeySize / BitsPerByte];
+            Rfc2898DeriveBytes.Pbkdf2(password.Value, binarySalt, binaryHash, DefaultIterations, s_hashAlgorithmName);
 
-        using var aes = Aes.Create();
-        aes.Key = binaryHash;
-        var writtenBytes = aes.EncryptCbc(binaryKey, binarySalt[..(AesMaxIvSize / BitsPerByte)], encrypted);
+            Span<byte> encrypted = stackalloc byte[DefaultKeyLengthBits];
 
-        return new CreateKeyResult(
-            Salt: Convert.ToBase64String(binarySalt),
-            EncryptedKey: Convert.ToBase64String(encrypted[..writtenBytes]));
+            using var aes = Aes.Create();
+            aes.Key = binaryHash;
+            var writtenBytes = aes.EncryptCbc(binaryKey, binarySalt[..(AesMaxIvSize / BitsPerByte)], encrypted);
+
+            return Pbkdf2PhcString.Create(
+                salt: Convert.ToBase64String(binarySalt),
+                encryptedKey: Convert.ToBase64String(encrypted[..writtenBytes]),
+                iterations: DefaultIterations,
+                keyLengthBits: DefaultKeyLengthBits);
+        }
+        catch (CryptographicException e)
+        {
+            LogCryptographicException(e);
+            return CryptographyError.Failed;
+        }
     }
 
-    public Result<string, GetKeyError> TryGetKey(
-        string password,
-        string salt,
-        string encryptedKey,
-        int keySize,
-        int iterations)
+    public Result<string, GetKeyError> TryGetKey(string password, string passwordHash)
     {
-        Span<byte> binarySalt = stackalloc byte[keySize / BitsPerByte];
-        if (!Convert.TryFromBase64Chars(salt, binarySalt, out var saltBytes) || saltBytes != binarySalt.Length)
-        {
-            return GetKeyError.InvalidSalt;
-        }
+        return from phcString in Pbkdf2PhcString.Parse(passwordHash)
+               from key in DecryptKey(password, phcString)
+               select key;
+    }
 
-        Span<byte> binaryEncrypted = stackalloc byte[keySize];
-        if (!Convert.TryFromBase64Chars(encryptedKey, binaryEncrypted, out var encryptedBytes))
-        {
-            return GetKeyError.InvalidEncryptedKey;
-        }
+    private Result<string, GetKeyError> DecryptKey(string password, Pbkdf2PhcString phcString)
+    {
+        var keyLengthBytes = phcString.KeyLengthBits / BitsPerByte;
+
+        Span<byte> binarySalt = stackalloc byte[keyLengthBytes];
+        if (!Convert.TryFromBase64Chars(phcString.Salt, binarySalt, out var saltBytes) || saltBytes != binarySalt.Length)
+            return GetKeyError.InvalidPassword;
+
+        Span<byte> binaryEncrypted = stackalloc byte[phcString.KeyLengthBits];
+        if (!Convert.TryFromBase64Chars(phcString.EncryptedKey, binaryEncrypted, out var encryptedBytes))
+            return GetKeyError.InvalidPassword;
 
         var binaryHash = new byte[AesMaxKeySize / BitsPerByte];
-        Rfc2898DeriveBytes.Pbkdf2(password, binarySalt, binaryHash, iterations, s_hashAlgorithmName);
+        Rfc2898DeriveBytes.Pbkdf2(password, binarySalt, binaryHash, phcString.Iterations, s_hashAlgorithmName);
 
-        Span<byte> binaryKey = stackalloc byte[keySize / BitsPerByte];
+        Span<byte> binaryKey = stackalloc byte[keyLengthBytes];
 
         Aes? aes = null;
         try

--- a/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2KeyDerivation.cs
+++ b/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2KeyDerivation.cs
@@ -23,36 +23,44 @@ public sealed partial class Pbkdf2KeyDerivation : IKeyDerivation
 
     public Result<IPhcString, CryptographyError> CreateKey(Password password)
     {
+        var keyLengthBytes = DefaultKeyLengthBits / BitsPerByte;
+
+        Span<byte> binarySalt = stackalloc byte[keyLengthBytes];
+        RandomNumberGenerator.Fill(binarySalt);
+
+        Span<byte> binaryKey = stackalloc byte[keyLengthBytes];
+        RandomNumberGenerator.Fill(binaryKey);
+
+        var binaryHash = new byte[AesMaxKeySize / BitsPerByte];
         try
         {
-            var keyLengthBytes = DefaultKeyLengthBits / BitsPerByte;
-
-            Span<byte> binarySalt = stackalloc byte[keyLengthBytes];
-            RandomNumberGenerator.Fill(binarySalt);
-
-            Span<byte> binaryKey = stackalloc byte[keyLengthBytes];
-            RandomNumberGenerator.Fill(binaryKey);
-
-            var binaryHash = new byte[AesMaxKeySize / BitsPerByte];
             Rfc2898DeriveBytes.Pbkdf2(password.Value, binarySalt, binaryHash, DefaultIterations, s_hashAlgorithmName);
-
-            Span<byte> encrypted = stackalloc byte[DefaultKeyLengthBits];
-
-            using var aes = Aes.Create();
-            aes.Key = binaryHash;
-            var writtenBytes = aes.EncryptCbc(binaryKey, binarySalt[..(AesMaxIvSize / BitsPerByte)], encrypted);
-
-            return Pbkdf2PhcString.Create(
-                salt: Convert.ToBase64String(binarySalt),
-                encryptedKey: Convert.ToBase64String(encrypted[..writtenBytes]),
-                iterations: DefaultIterations,
-                keyLengthBits: DefaultKeyLengthBits);
         }
         catch (CryptographicException e)
         {
             LogCryptographicException(e);
-            return CryptographyError.Failed;
+            return CryptographyError.KeyDerivationFailed;
         }
+
+        Span<byte> encrypted = stackalloc byte[DefaultKeyLengthBits];
+        int writtenBytes;
+        try
+        {
+            using var aes = Aes.Create();
+            aes.Key = binaryHash;
+            writtenBytes = aes.EncryptCbc(binaryKey, binarySalt[..(AesMaxIvSize / BitsPerByte)], encrypted);
+        }
+        catch (CryptographicException e)
+        {
+            LogCryptographicException(e);
+            return CryptographyError.EncryptionFailed;
+        }
+
+        return Pbkdf2PhcString.Create(
+            salt: Convert.ToBase64String(binarySalt),
+            encryptedKey: Convert.ToBase64String(encrypted[..writtenBytes]),
+            iterations: DefaultIterations,
+            keyLengthBits: DefaultKeyLengthBits);
     }
 
     public Result<string, GetKeyError> TryGetKey(string password, string passwordHash)
@@ -109,6 +117,6 @@ public sealed partial class Pbkdf2KeyDerivation : IKeyDerivation
         }
     }
 
-    [LoggerMessage(LogLevel.Error, "Error decrypting CBC")]
+    [LoggerMessage(LogLevel.Error, "Error during cryptographic operation")]
     private partial void LogCryptographicException(CryptographicException exception);
 }

--- a/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2KeyDerivation.cs
+++ b/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2KeyDerivation.cs
@@ -15,10 +15,12 @@ public sealed partial class Pbkdf2KeyDerivation : IKeyDerivation
     private static readonly HashAlgorithmName s_hashAlgorithmName = HashAlgorithmName.SHA512;
 
     private readonly ILogger<Pbkdf2KeyDerivation> _logger;
+    private readonly IPbkdf2PhcStringParser _phcStringParser;
 
-    public Pbkdf2KeyDerivation(ILogger<Pbkdf2KeyDerivation> logger)
+    public Pbkdf2KeyDerivation(ILogger<Pbkdf2KeyDerivation> logger, IPbkdf2PhcStringParser phcStringParser)
     {
         _logger = logger;
+        _phcStringParser = phcStringParser;
     }
 
     public Result<IPhcString, CryptographyError> CreateKey(Password password)
@@ -56,7 +58,7 @@ public sealed partial class Pbkdf2KeyDerivation : IKeyDerivation
             return CryptographyError.EncryptionFailed;
         }
 
-        return Pbkdf2PhcString.Create(
+        return _phcStringParser.Create(
             salt: Convert.ToBase64String(binarySalt),
             encryptedKey: Convert.ToBase64String(encrypted[..writtenBytes]),
             iterations: DefaultIterations,
@@ -65,7 +67,7 @@ public sealed partial class Pbkdf2KeyDerivation : IKeyDerivation
 
     public Result<string, GetKeyError> TryGetKey(string password, string passwordHash)
     {
-        return from phcString in Pbkdf2PhcString.Parse(passwordHash)
+        return from phcString in _phcStringParser.Parse(passwordHash)
                from key in DecryptKey(password, phcString)
                select key;
     }
@@ -83,7 +85,15 @@ public sealed partial class Pbkdf2KeyDerivation : IKeyDerivation
             return GetKeyError.InvalidPassword;
 
         var binaryHash = new byte[AesMaxKeySize / BitsPerByte];
-        Rfc2898DeriveBytes.Pbkdf2(password, binarySalt, binaryHash, phcString.Iterations, s_hashAlgorithmName);
+        try
+        {
+            Rfc2898DeriveBytes.Pbkdf2(password, binarySalt, binaryHash, phcString.Iterations, s_hashAlgorithmName);
+        }
+        catch (CryptographicException e)
+        {
+            LogCryptographicException(e);
+            return GetKeyError.InvalidPassword;
+        }
 
         Span<byte> binaryKey = stackalloc byte[keyLengthBytes];
 

--- a/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2PhcString.cs
+++ b/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2PhcString.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using PatrimonioTech.Domain.Credentials.Services;
 
 namespace PatrimonioTech.Infra.Credentials.Services;
@@ -9,9 +8,7 @@ namespace PatrimonioTech.Infra.Credentials.Services;
 /// </summary>
 public sealed class Pbkdf2PhcString : IPhcString
 {
-    private const string AlgorithmId = "pbkdf2-sha512-aes256cbc";
-
-    private Pbkdf2PhcString(string value, string salt, string encryptedKey, int iterations, int keyLengthBits)
+    internal Pbkdf2PhcString(string value, string salt, string encryptedKey, int iterations, int keyLengthBits)
     {
         Value = value;
         Salt = salt;
@@ -25,50 +22,4 @@ public sealed class Pbkdf2PhcString : IPhcString
     internal string EncryptedKey { get; }
     internal int Iterations { get; }
     internal int KeyLengthBits { get; }
-
-    internal static Pbkdf2PhcString Create(string salt, string encryptedKey, int iterations, int keyLengthBits)
-    {
-        var value = $"${AlgorithmId}$i={iterations},l={keyLengthBits}${salt}${encryptedKey}";
-        return new Pbkdf2PhcString(value, salt, encryptedKey, iterations, keyLengthBits);
-    }
-
-    internal static Result<Pbkdf2PhcString, GetKeyError> Parse(ReadOnlySpan<char> value)
-    {
-        Span<Range> ranges = stackalloc Range[6];
-        var count = value.Split(ranges, '$');
-
-        // Expected: ["", "pbkdf2-sha512-aes256cbc", "i=100000,l=512", saltBase64, encryptedKeyBase64]
-        if (count != 5 || !value[ranges[0]].IsEmpty || !value[ranges[1]].Equals(AlgorithmId, StringComparison.Ordinal))
-            return GetKeyError.InvalidHash;
-
-        if (!TryParseParams(value[ranges[2]], out var iterations, out var keyLengthBits))
-            return GetKeyError.InvalidHash;
-
-        return new Pbkdf2PhcString(value.ToString(), value[ranges[3]].ToString(), value[ranges[4]].ToString(), iterations, keyLengthBits);
-    }
-
-    private static bool TryParseParams(ReadOnlySpan<char> paramString, out int iterations, out int keyLengthBits)
-    {
-        iterations = 0;
-        keyLengthBits = 0;
-
-        foreach (var chunk in paramString.Split(','))
-        {
-            var param = paramString[chunk];
-            var eqIdx = param.IndexOf('=');
-            if (eqIdx < 0)
-                return false;
-
-            var key = param[..eqIdx];
-            if (!int.TryParse(param[(eqIdx + 1)..], CultureInfo.InvariantCulture, out var value))
-                return false;
-
-            if (key.Equals("i", StringComparison.Ordinal))
-                iterations = value;
-            else if (key.Equals("l", StringComparison.Ordinal))
-                keyLengthBits = value;
-        }
-
-        return iterations > 0 && keyLengthBits > 0;
-    }
 }

--- a/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2PhcString.cs
+++ b/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2PhcString.cs
@@ -1,0 +1,72 @@
+using System.Globalization;
+using PatrimonioTech.Domain.Credentials.Services;
+
+namespace PatrimonioTech.Infra.Credentials.Services;
+
+/// <summary>
+/// A PHC-format string encoding PBKDF2-SHA512 parameters and an AES-CBC encrypted database key.
+/// Format: $pbkdf2-sha512$i={iterations},l={keyLengthBits}${saltBase64}${encryptedKeyBase64}
+/// </summary>
+internal sealed class Pbkdf2PhcString : IPhcString
+{
+    private const string AlgorithmId = "pbkdf2-sha512";
+
+    private Pbkdf2PhcString(string value, string salt, string encryptedKey, int iterations, int keyLengthBits)
+    {
+        Value = value;
+        Salt = salt;
+        EncryptedKey = encryptedKey;
+        Iterations = iterations;
+        KeyLengthBits = keyLengthBits;
+    }
+
+    public string Value { get; }
+    internal string Salt { get; }
+    internal string EncryptedKey { get; }
+    internal int Iterations { get; }
+    internal int KeyLengthBits { get; }
+
+    internal static Pbkdf2PhcString Create(string salt, string encryptedKey, int iterations, int keyLengthBits)
+    {
+        var value = $"${AlgorithmId}$i={iterations},l={keyLengthBits}${salt}${encryptedKey}";
+        return new Pbkdf2PhcString(value, salt, encryptedKey, iterations, keyLengthBits);
+    }
+
+    internal static Result<Pbkdf2PhcString, GetKeyError> Parse(string value)
+    {
+        var parts = value.Split('$');
+
+        // Expected: ["", "pbkdf2-sha512", "i=100000,l=512", saltBase64, encryptedKeyBase64]
+        if (parts.Length != 5 || !string.Equals(parts[0], string.Empty, StringComparison.Ordinal) || !string.Equals(parts[1], AlgorithmId, StringComparison.Ordinal))
+            return GetKeyError.InvalidPassword;
+
+        if (!TryParseParams(parts[2], out var iterations, out var keyLengthBits))
+            return GetKeyError.InvalidPassword;
+
+        return new Pbkdf2PhcString(value, parts[3], parts[4], iterations, keyLengthBits);
+    }
+
+    private static bool TryParseParams(string paramString, out int iterations, out int keyLengthBits)
+    {
+        iterations = 0;
+        keyLengthBits = 0;
+
+        foreach (var param in paramString.Split(','))
+        {
+            var eqIdx = param.IndexOf('=');
+            if (eqIdx < 0)
+                return false;
+
+            var key = param[..eqIdx];
+            if (!int.TryParse(param[(eqIdx + 1)..], CultureInfo.InvariantCulture, out var value))
+                return false;
+
+            if (string.Equals(key, "i", StringComparison.Ordinal))
+                iterations = value;
+            else if (string.Equals(key, "l", StringComparison.Ordinal))
+                keyLengthBits = value;
+        }
+
+        return iterations > 0 && keyLengthBits > 0;
+    }
+}

--- a/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2PhcString.cs
+++ b/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2PhcString.cs
@@ -7,7 +7,7 @@ namespace PatrimonioTech.Infra.Credentials.Services;
 /// A PHC-format string encoding PBKDF2-SHA512 parameters and an AES-256-CBC encrypted database key.
 /// Format: $pbkdf2-sha512-aes256cbc$i={iterations},l={keyLengthBits}${saltBase64}${encryptedKeyBase64}
 /// </summary>
-internal sealed class Pbkdf2PhcString : IPhcString
+public sealed class Pbkdf2PhcString : IPhcString
 {
     private const string AlgorithmId = "pbkdf2-sha512-aes256cbc";
 

--- a/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2PhcString.cs
+++ b/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2PhcString.cs
@@ -4,12 +4,12 @@ using PatrimonioTech.Domain.Credentials.Services;
 namespace PatrimonioTech.Infra.Credentials.Services;
 
 /// <summary>
-/// A PHC-format string encoding PBKDF2-SHA512 parameters and an AES-CBC encrypted database key.
-/// Format: $pbkdf2-sha512$i={iterations},l={keyLengthBits}${saltBase64}${encryptedKeyBase64}
+/// A PHC-format string encoding PBKDF2-SHA512 parameters and an AES-256-CBC encrypted database key.
+/// Format: $pbkdf2-sha512-aes256cbc$i={iterations},l={keyLengthBits}${saltBase64}${encryptedKeyBase64}
 /// </summary>
 internal sealed class Pbkdf2PhcString : IPhcString
 {
-    private const string AlgorithmId = "pbkdf2-sha512";
+    private const string AlgorithmId = "pbkdf2-sha512-aes256cbc";
 
     private Pbkdf2PhcString(string value, string salt, string encryptedKey, int iterations, int keyLengthBits)
     {
@@ -32,27 +32,29 @@ internal sealed class Pbkdf2PhcString : IPhcString
         return new Pbkdf2PhcString(value, salt, encryptedKey, iterations, keyLengthBits);
     }
 
-    internal static Result<Pbkdf2PhcString, GetKeyError> Parse(string value)
+    internal static Result<Pbkdf2PhcString, GetKeyError> Parse(ReadOnlySpan<char> value)
     {
-        var parts = value.Split('$');
+        Span<Range> ranges = stackalloc Range[6];
+        var count = value.Split(ranges, '$');
 
-        // Expected: ["", "pbkdf2-sha512", "i=100000,l=512", saltBase64, encryptedKeyBase64]
-        if (parts.Length != 5 || !string.Equals(parts[0], string.Empty, StringComparison.Ordinal) || !string.Equals(parts[1], AlgorithmId, StringComparison.Ordinal))
-            return GetKeyError.InvalidPassword;
+        // Expected: ["", "pbkdf2-sha512-aes256cbc", "i=100000,l=512", saltBase64, encryptedKeyBase64]
+        if (count != 5 || !value[ranges[0]].IsEmpty || !value[ranges[1]].Equals(AlgorithmId, StringComparison.Ordinal))
+            return GetKeyError.InvalidHash;
 
-        if (!TryParseParams(parts[2], out var iterations, out var keyLengthBits))
-            return GetKeyError.InvalidPassword;
+        if (!TryParseParams(value[ranges[2]], out var iterations, out var keyLengthBits))
+            return GetKeyError.InvalidHash;
 
-        return new Pbkdf2PhcString(value, parts[3], parts[4], iterations, keyLengthBits);
+        return new Pbkdf2PhcString(value.ToString(), value[ranges[3]].ToString(), value[ranges[4]].ToString(), iterations, keyLengthBits);
     }
 
-    private static bool TryParseParams(string paramString, out int iterations, out int keyLengthBits)
+    private static bool TryParseParams(ReadOnlySpan<char> paramString, out int iterations, out int keyLengthBits)
     {
         iterations = 0;
         keyLengthBits = 0;
 
-        foreach (var param in paramString.Split(','))
+        foreach (var chunk in paramString.Split(','))
         {
+            var param = paramString[chunk];
             var eqIdx = param.IndexOf('=');
             if (eqIdx < 0)
                 return false;
@@ -61,9 +63,9 @@ internal sealed class Pbkdf2PhcString : IPhcString
             if (!int.TryParse(param[(eqIdx + 1)..], CultureInfo.InvariantCulture, out var value))
                 return false;
 
-            if (string.Equals(key, "i", StringComparison.Ordinal))
+            if (key.Equals("i", StringComparison.Ordinal))
                 iterations = value;
-            else if (string.Equals(key, "l", StringComparison.Ordinal))
+            else if (key.Equals("l", StringComparison.Ordinal))
                 keyLengthBits = value;
         }
 

--- a/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2PhcStringParser.cs
+++ b/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2PhcStringParser.cs
@@ -1,12 +1,56 @@
+using System.Globalization;
 using PatrimonioTech.Domain.Credentials.Services;
 
 namespace PatrimonioTech.Infra.Credentials.Services;
 
 public sealed class Pbkdf2PhcStringParser : IPbkdf2PhcStringParser
 {
-    public Pbkdf2PhcString Create(string salt, string encryptedKey, int iterations, int keyLengthBits) =>
-        Pbkdf2PhcString.Create(salt, encryptedKey, iterations, keyLengthBits);
+    private const string AlgorithmId = "pbkdf2-sha512-aes256cbc";
 
-    public Result<Pbkdf2PhcString, GetKeyError> Parse(ReadOnlySpan<char> value) =>
-        Pbkdf2PhcString.Parse(value);
+    public Pbkdf2PhcString Create(string salt, string encryptedKey, int iterations, int keyLengthBits)
+    {
+        var value = $"${AlgorithmId}$i={iterations},l={keyLengthBits}${salt}${encryptedKey}";
+        return new Pbkdf2PhcString(value, salt, encryptedKey, iterations, keyLengthBits);
+    }
+
+    public Result<Pbkdf2PhcString, GetKeyError> Parse(ReadOnlySpan<char> value)
+    {
+        Span<Range> ranges = stackalloc Range[6];
+        var count = value.Split(ranges, '$');
+
+        if (count != 5 || !value[ranges[0]].IsEmpty || !value[ranges[1]].Equals(AlgorithmId, StringComparison.Ordinal))
+            return GetKeyError.InvalidHash;
+
+        if (!TryParseParams(value[ranges[2]], out var iterations, out var keyLengthBits))
+            return GetKeyError.InvalidHash;
+
+        return new Pbkdf2PhcString(value.ToString(), value[ranges[3]].ToString(), value[ranges[4]].ToString(), iterations, keyLengthBits);
+    }
+
+    private static bool TryParseParams(ReadOnlySpan<char> paramString, out int iterations, out int keyLengthBits)
+    {
+        iterations = 0;
+        keyLengthBits = 0;
+
+        foreach (var chunk in paramString.Split(','))
+        {
+            var param = paramString[chunk];
+            var eqIdx = param.IndexOf('=');
+            if (eqIdx < 0)
+                return false;
+
+            var key = param[..eqIdx];
+            if (!int.TryParse(param[(eqIdx + 1)..], CultureInfo.InvariantCulture, out var val))
+                return false;
+
+            if (key.Equals("i", StringComparison.Ordinal))
+                iterations = val;
+            else if (key.Equals("l", StringComparison.Ordinal))
+                keyLengthBits = val;
+            else
+                return false;
+        }
+
+        return iterations > 0 && keyLengthBits > 0;
+    }
 }

--- a/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2PhcStringParser.cs
+++ b/src/PatrimonioTech.Infra/Credentials/Services/Pbkdf2PhcStringParser.cs
@@ -1,0 +1,12 @@
+using PatrimonioTech.Domain.Credentials.Services;
+
+namespace PatrimonioTech.Infra.Credentials.Services;
+
+public sealed class Pbkdf2PhcStringParser : IPbkdf2PhcStringParser
+{
+    public Pbkdf2PhcString Create(string salt, string encryptedKey, int iterations, int keyLengthBits) =>
+        Pbkdf2PhcString.Create(salt, encryptedKey, iterations, keyLengthBits);
+
+    public Result<Pbkdf2PhcString, GetKeyError> Parse(ReadOnlySpan<char> value) =>
+        Pbkdf2PhcString.Parse(value);
+}

--- a/src/PatrimonioTech.Infra/Credentials/UserCredentialModel.cs
+++ b/src/PatrimonioTech.Infra/Credentials/UserCredentialModel.cs
@@ -1,9 +1,3 @@
-﻿namespace PatrimonioTech.Infra.Credentials;
+namespace PatrimonioTech.Infra.Credentials;
 
-public sealed record UserCredentialModel(
-    string Name,
-    string Salt,
-    string Key,
-    Guid Database,
-    int KeySize,
-    int Iterations);
+public sealed record UserCredentialModel(string Name, string PasswordHash, Guid Database);

--- a/src/PatrimonioTech.Infra/Credentials/UserCredentialModelMapper.cs
+++ b/src/PatrimonioTech.Infra/Credentials/UserCredentialModelMapper.cs
@@ -1,4 +1,4 @@
-﻿using PatrimonioTech.Domain.Credentials;
+using PatrimonioTech.Domain.Credentials;
 using PatrimonioTech.Domain.Credentials.Actions.AddUser;
 using Riok.Mapperly.Abstractions;
 

--- a/src/PatrimonioTech.Infra/DependencyInjection/IInfraModule.cs
+++ b/src/PatrimonioTech.Infra/DependencyInjection/IInfraModule.cs
@@ -13,6 +13,7 @@ namespace PatrimonioTech.Infra.DependencyInjection;
 [ServiceProviderModule]
 [Import(typeof(IOptionsModule))]
 [Import(typeof(ILoggingModule))]
+[Singleton(typeof(IPbkdf2PhcStringParser), typeof(Pbkdf2PhcStringParser))]
 [Singleton(typeof(IKeyDerivation), typeof(Pbkdf2KeyDerivation))]
 [Scoped(typeof(IUserCredentialRepository), typeof(FileUserCredentialRepository))]
 [Singleton(typeof(IDatabaseAdmin), typeof(LiteDbDatabaseAdmin))]

--- a/tests/PatrimonioTech.App.Tests/Credentials/v1/AddUser/CredentialAddUserUseCaseTest.cs
+++ b/tests/PatrimonioTech.App.Tests/Credentials/v1/AddUser/CredentialAddUserUseCaseTest.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using JetBrains.Annotations;
 using NSubstitute;
 using PatrimonioTech.App.Credentials.v1.AddUser;
@@ -18,6 +18,9 @@ public class CredentialAddUserUseCaseTest
     private readonly IKeyDerivation _keyDerivation = Substitute.For<IKeyDerivation>();
     private readonly CredentialAddUserUseCase _sut;
 
+    private static readonly UserCredentialAdded ValidAdded =
+        new("john", "$pbkdf2-sha512$i=100000,l=512$salt$key", Guid.Empty);
+
     public CredentialAddUserUseCaseTest()
     {
         _sut = new CredentialAddUserUseCase(
@@ -33,12 +36,12 @@ public class CredentialAddUserUseCaseTest
         // Arrange
         _addUserScenario
             .Execute(Arg.Any<AddUserCredential>())
-            .Returns(new UserCredentialAdded("john", "123", "password", Guid.Empty, 1, 1));
+            .Returns(ValidAdded);
         _userCredentialRepository
             .Add(Arg.Any<UserCredential>(), CancellationToken.None)
             .Returns(Unit.Default);
         _keyDerivation
-            .TryGetKey(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>())
+            .TryGetKey(Arg.Any<string>(), Arg.Any<string>())
             .Returns("password");
         _databaseAdmin
             .CreateDatabase(Guid.Empty, Arg.Any<string>())
@@ -75,12 +78,12 @@ public class CredentialAddUserUseCaseTest
         // Arrange
         _addUserScenario
             .Execute(Arg.Any<AddUserCredential>())
-            .Returns(new UserCredentialAdded("john", "123", "password", Guid.Empty, 1, 1));
+            .Returns(ValidAdded);
         _userCredentialRepository
             .Add(Arg.Any<UserCredential>(), CancellationToken.None)
             .Returns(Unit.Default);
         _keyDerivation
-            .TryGetKey(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>())
+            .TryGetKey(Arg.Any<string>(), Arg.Any<string>())
             .Returns(GetKeyError.InvalidPassword);
 
         // Act
@@ -98,9 +101,9 @@ public class CredentialAddUserUseCaseTest
         // Arrange
         _addUserScenario
             .Execute(Arg.Any<AddUserCredential>())
-            .Returns(new UserCredentialAdded("john", "123", "password", Guid.Empty, 1, 1));
+            .Returns(ValidAdded);
         _keyDerivation
-            .TryGetKey(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>())
+            .TryGetKey(Arg.Any<string>(), Arg.Any<string>())
             .Returns("password");
         _databaseAdmin
             .CreateDatabase(Guid.Empty, Arg.Any<string>())
@@ -120,9 +123,9 @@ public class CredentialAddUserUseCaseTest
         // Arrange
         _addUserScenario
             .Execute(Arg.Any<AddUserCredential>())
-            .Returns(new UserCredentialAdded("john", "123", "password", Guid.Empty, 1, 1));
+            .Returns(ValidAdded);
         _keyDerivation
-            .TryGetKey(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>())
+            .TryGetKey(Arg.Any<string>(), Arg.Any<string>())
             .Returns("password");
         _databaseAdmin
             .CreateDatabase(Guid.Empty, Arg.Any<string>())

--- a/tests/PatrimonioTech.App.Tests/Credentials/v1/AddUser/CredentialAddUserUseCaseTest.cs
+++ b/tests/PatrimonioTech.App.Tests/Credentials/v1/AddUser/CredentialAddUserUseCaseTest.cs
@@ -19,7 +19,7 @@ public class CredentialAddUserUseCaseTest
     private readonly CredentialAddUserUseCase _sut;
 
     private static readonly UserCredentialAdded ValidAdded =
-        new("john", "$pbkdf2-sha512$i=100000,l=512$salt$key", Guid.Empty);
+        new("john", "$pbkdf2-sha512-aes256cbc$i=100000,l=512$salt$key", Guid.Empty);
 
     public CredentialAddUserUseCaseTest()
     {

--- a/tests/PatrimonioTech.App.Tests/Credentials/v1/GetUserAvailability/UserGetAvailabilityUseCaseTest.cs
+++ b/tests/PatrimonioTech.App.Tests/Credentials/v1/GetUserAvailability/UserGetAvailabilityUseCaseTest.cs
@@ -52,8 +52,8 @@ public class UserGetAvailabilityUseCaseTest
 
     private static IReadOnlyList<UserCredential> CredentialsFixture =>
     [
-        UserCredential.Create(new UserCredentialAdded("John", "$pbkdf2-sha512$i=100000,l=512$salt1$key1", Guid.Empty)),
-        UserCredential.Create(new UserCredentialAdded("Carl", "$pbkdf2-sha512$i=100000,l=512$salt2$key2", Guid.Empty)),
-        UserCredential.Create(new UserCredentialAdded("Anne", "$pbkdf2-sha512$i=100000,l=512$salt3$key3", Guid.Empty)),
+        UserCredential.Create(new UserCredentialAdded("John", "$pbkdf2-sha512-aes256cbc$i=100000,l=512$salt1$key1", Guid.Empty)),
+        UserCredential.Create(new UserCredentialAdded("Carl", "$pbkdf2-sha512-aes256cbc$i=100000,l=512$salt2$key2", Guid.Empty)),
+        UserCredential.Create(new UserCredentialAdded("Anne", "$pbkdf2-sha512-aes256cbc$i=100000,l=512$salt3$key3", Guid.Empty)),
     ];
 }

--- a/tests/PatrimonioTech.App.Tests/Credentials/v1/GetUserAvailability/UserGetAvailabilityUseCaseTest.cs
+++ b/tests/PatrimonioTech.App.Tests/Credentials/v1/GetUserAvailability/UserGetAvailabilityUseCaseTest.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using JetBrains.Annotations;
 using NSubstitute;
 using PatrimonioTech.App.Credentials.v1.GetUserAvailability;
@@ -52,8 +52,8 @@ public class UserGetAvailabilityUseCaseTest
 
     private static IReadOnlyList<UserCredential> CredentialsFixture =>
     [
-        UserCredential.Create(new UserCredentialAdded("John", "123", "password", Guid.Empty, 1, 1)),
-        UserCredential.Create(new UserCredentialAdded("Carl", "456", "password", Guid.Empty, 2, 1)),
-        UserCredential.Create(new UserCredentialAdded("Anne", "789", "password", Guid.Empty, 3, 1)),
+        UserCredential.Create(new UserCredentialAdded("John", "$pbkdf2-sha512$i=100000,l=512$salt1$key1", Guid.Empty)),
+        UserCredential.Create(new UserCredentialAdded("Carl", "$pbkdf2-sha512$i=100000,l=512$salt2$key2", Guid.Empty)),
+        UserCredential.Create(new UserCredentialAdded("Anne", "$pbkdf2-sha512$i=100000,l=512$salt3$key3", Guid.Empty)),
     ];
 }

--- a/tests/PatrimonioTech.App.Tests/Credentials/v1/GetUserInfo/CredentialGetUserInfoUseCaseTest.cs
+++ b/tests/PatrimonioTech.App.Tests/Credentials/v1/GetUserInfo/CredentialGetUserInfoUseCaseTest.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using JetBrains.Annotations;
 using NSubstitute;
 using PatrimonioTech.App.Credentials.v1.GetUserInfo;
@@ -29,7 +29,7 @@ public class CredentialGetUserInfoUseCaseTest
     {
         // Arrange
         _keyDerivation
-            .TryGetKey("password", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>())
+            .TryGetKey("password", Arg.Any<string>())
             .Returns("secret");
 
         // Act
@@ -54,7 +54,7 @@ public class CredentialGetUserInfoUseCaseTest
     {
         // Arrange
         _keyDerivation
-            .TryGetKey("password", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<int>())
+            .TryGetKey("password", Arg.Any<string>())
             .Returns(GetKeyError.InvalidPassword);
 
         // Act
@@ -66,8 +66,8 @@ public class CredentialGetUserInfoUseCaseTest
 
     private static IReadOnlyList<UserCredential> CredentialsFixture =>
     [
-        UserCredential.Create(new UserCredentialAdded("John", "123", "password", Guid.Empty, 1, 1)),
-        UserCredential.Create(new UserCredentialAdded("Carl", "456", "password", Guid.Empty, 2, 1)),
-        UserCredential.Create(new UserCredentialAdded("Anne", "789", "password", Guid.Empty, 3, 1)),
+        UserCredential.Create(new UserCredentialAdded("John", "$pbkdf2-sha512$i=100000,l=512$salt1$key1", Guid.Empty)),
+        UserCredential.Create(new UserCredentialAdded("Carl", "$pbkdf2-sha512$i=100000,l=512$salt2$key2", Guid.Empty)),
+        UserCredential.Create(new UserCredentialAdded("Anne", "$pbkdf2-sha512$i=100000,l=512$salt3$key3", Guid.Empty)),
     ];
 }

--- a/tests/PatrimonioTech.App.Tests/Credentials/v1/GetUserInfo/CredentialGetUserInfoUseCaseTest.cs
+++ b/tests/PatrimonioTech.App.Tests/Credentials/v1/GetUserInfo/CredentialGetUserInfoUseCaseTest.cs
@@ -66,8 +66,8 @@ public class CredentialGetUserInfoUseCaseTest
 
     private static IReadOnlyList<UserCredential> CredentialsFixture =>
     [
-        UserCredential.Create(new UserCredentialAdded("John", "$pbkdf2-sha512$i=100000,l=512$salt1$key1", Guid.Empty)),
-        UserCredential.Create(new UserCredentialAdded("Carl", "$pbkdf2-sha512$i=100000,l=512$salt2$key2", Guid.Empty)),
-        UserCredential.Create(new UserCredentialAdded("Anne", "$pbkdf2-sha512$i=100000,l=512$salt3$key3", Guid.Empty)),
+        UserCredential.Create(new UserCredentialAdded("John", "$pbkdf2-sha512-aes256cbc$i=100000,l=512$salt1$key1", Guid.Empty)),
+        UserCredential.Create(new UserCredentialAdded("Carl", "$pbkdf2-sha512-aes256cbc$i=100000,l=512$salt2$key2", Guid.Empty)),
+        UserCredential.Create(new UserCredentialAdded("Anne", "$pbkdf2-sha512-aes256cbc$i=100000,l=512$salt3$key3", Guid.Empty)),
     ];
 }

--- a/tests/PatrimonioTech.App.Tests/Credentials/v1/GetUsers/CredentialGetUsersUseCaseTest.cs
+++ b/tests/PatrimonioTech.App.Tests/Credentials/v1/GetUsers/CredentialGetUsersUseCaseTest.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using JetBrains.Annotations;
 using NSubstitute;
 using PatrimonioTech.App.Credentials.v1.GetUsers;
@@ -27,9 +27,9 @@ public class CredentialGetUsersUseCaseTest
             .GetAll(CancellationToken.None)
             .Returns(
             [
-                UserCredential.Create(new UserCredentialAdded("John", "123", "password", Guid.Empty, 1, 1)),
-                UserCredential.Create(new UserCredentialAdded("Carl", "456", "password", Guid.Empty, 2, 1)),
-                UserCredential.Create(new UserCredentialAdded("Anne", "789", "password", Guid.Empty, 3, 1)),
+                UserCredential.Create(new UserCredentialAdded("John", "$pbkdf2-sha512$i=100000,l=512$salt1$key1", Guid.Empty)),
+                UserCredential.Create(new UserCredentialAdded("Carl", "$pbkdf2-sha512$i=100000,l=512$salt2$key2", Guid.Empty)),
+                UserCredential.Create(new UserCredentialAdded("Anne", "$pbkdf2-sha512$i=100000,l=512$salt3$key3", Guid.Empty)),
             ]);
 
         // Act

--- a/tests/PatrimonioTech.App.Tests/Credentials/v1/GetUsers/CredentialGetUsersUseCaseTest.cs
+++ b/tests/PatrimonioTech.App.Tests/Credentials/v1/GetUsers/CredentialGetUsersUseCaseTest.cs
@@ -27,9 +27,9 @@ public class CredentialGetUsersUseCaseTest
             .GetAll(CancellationToken.None)
             .Returns(
             [
-                UserCredential.Create(new UserCredentialAdded("John", "$pbkdf2-sha512$i=100000,l=512$salt1$key1", Guid.Empty)),
-                UserCredential.Create(new UserCredentialAdded("Carl", "$pbkdf2-sha512$i=100000,l=512$salt2$key2", Guid.Empty)),
-                UserCredential.Create(new UserCredentialAdded("Anne", "$pbkdf2-sha512$i=100000,l=512$salt3$key3", Guid.Empty)),
+                UserCredential.Create(new UserCredentialAdded("John", "$pbkdf2-sha512-aes256cbc$i=100000,l=512$salt1$key1", Guid.Empty)),
+                UserCredential.Create(new UserCredentialAdded("Carl", "$pbkdf2-sha512-aes256cbc$i=100000,l=512$salt2$key2", Guid.Empty)),
+                UserCredential.Create(new UserCredentialAdded("Anne", "$pbkdf2-sha512-aes256cbc$i=100000,l=512$salt3$key3", Guid.Empty)),
             ]);
 
         // Act

--- a/tests/PatrimonioTech.Domain.Tests/Credentials/Actions/AddUser/AddUserScenarioTests.cs
+++ b/tests/PatrimonioTech.Domain.Tests/Credentials/Actions/AddUser/AddUserScenarioTests.cs
@@ -10,11 +10,7 @@ namespace PatrimonioTech.Domain.Tests.Credentials.Actions.AddUser;
 [TestSubject(typeof(AddUserScenario))]
 public class AddUserScenarioTests
 {
-    private static readonly AddUserCredential ValidCommand = new(
-        "ValidUser",
-        "password1",
-        UserCredential.DefaultKeySize,
-        UserCredential.DefaultIterations);
+    private static readonly AddUserCredential ValidCommand = new("ValidUser", "password1");
 
     private readonly IKeyDerivation _keyDerivation = Substitute.For<IKeyDerivation>();
     private readonly AddUserScenario _sut;
@@ -22,8 +18,8 @@ public class AddUserScenarioTests
     public AddUserScenarioTests()
     {
         _keyDerivation
-            .CreateKey(Arg.Any<Password>(), Arg.Any<int>(), Arg.Any<int>())
-            .Returns(new CreateKeyResult("salt123", "encryptedKey456"));
+            .CreateKey(Arg.Any<Password>())
+            .Returns(new TestPhcString("$pbkdf2-sha512$i=100000,l=512$salt$key"));
         _sut = new AddUserScenario(_keyDerivation);
     }
 
@@ -97,12 +93,22 @@ public class AddUserScenarioTests
     }
 
     [Fact]
+    public void Execute_WithKeyDerivationFailure_ReturnsKeyDerivationFailed()
+    {
+        _keyDerivation.CreateKey(Arg.Any<Password>()).Returns(CryptographyError.Failed);
+
+        var result = _sut.Execute(ValidCommand);
+
+        result.Should().BeErr().Should().BeOfType<AddUserCredentialError.KeyDerivationFailed>();
+    }
+
+    [Fact]
     public void Execute_WithValidInputs_CallsKeyDerivationAndReturnsOk()
     {
         var result = _sut.Execute(ValidCommand);
 
         result.Should().BeOk();
-        _keyDerivation.Received(1).CreateKey(Arg.Any<Password>(), Arg.Any<int>(), Arg.Any<int>());
+        _keyDerivation.Received(1).CreateKey(Arg.Any<Password>());
     }
 
     [Fact]
@@ -112,8 +118,9 @@ public class AddUserScenarioTests
 
         var added = result.Should().BeOk();
         added.Name.Should().Be(ValidCommand.Name);
-        added.Salt.Should().Be("salt123");
-        added.Key.Should().Be("encryptedKey456");
+        added.PasswordHash.Should().Be("$pbkdf2-sha512$i=100000,l=512$salt$key");
         added.Database.Should().NotBe(Guid.Empty);
     }
+
+    private sealed record TestPhcString(string Value) : IPhcString;
 }

--- a/tests/PatrimonioTech.Domain.Tests/Credentials/Actions/AddUser/AddUserScenarioTests.cs
+++ b/tests/PatrimonioTech.Domain.Tests/Credentials/Actions/AddUser/AddUserScenarioTests.cs
@@ -19,7 +19,7 @@ public class AddUserScenarioTests
     {
         _keyDerivation
             .CreateKey(Arg.Any<Password>())
-            .Returns(new TestPhcString("$pbkdf2-sha512$i=100000,l=512$salt$key"));
+            .Returns(new TestPhcString("$pbkdf2-sha512-aes256cbc$i=100000,l=512$salt$key"));
         _sut = new AddUserScenario(_keyDerivation);
     }
 
@@ -95,7 +95,7 @@ public class AddUserScenarioTests
     [Fact]
     public void Execute_WithKeyDerivationFailure_ReturnsKeyDerivationFailed()
     {
-        _keyDerivation.CreateKey(Arg.Any<Password>()).Returns(CryptographyError.Failed);
+        _keyDerivation.CreateKey(Arg.Any<Password>()).Returns(CryptographyError.KeyDerivationFailed);
 
         var result = _sut.Execute(ValidCommand);
 
@@ -118,7 +118,7 @@ public class AddUserScenarioTests
 
         var added = result.Should().BeOk();
         added.Name.Should().Be(ValidCommand.Name);
-        added.PasswordHash.Should().Be("$pbkdf2-sha512$i=100000,l=512$salt$key");
+        added.PasswordHash.Should().Be("$pbkdf2-sha512-aes256cbc$i=100000,l=512$salt$key");
         added.Database.Should().NotBe(Guid.Empty);
     }
 

--- a/tests/PatrimonioTech.Infra.Tests/Credentials/v1/FileUserCredentialRepositoryTests.cs
+++ b/tests/PatrimonioTech.Infra.Tests/Credentials/v1/FileUserCredentialRepositoryTests.cs
@@ -99,7 +99,7 @@ public sealed class FileUserCredentialRepositoryTests : IDisposable
 
     private static UserCredential MakeCredential(string name) =>
         UserCredential.Create(
-            new UserCredentialAdded(name, "$pbkdf2-sha512$i=100000,l=512$salt$key", Guid.NewGuid()));
+            new UserCredentialAdded(name, "$pbkdf2-sha512-aes256cbc$i=100000,l=512$salt$key", Guid.NewGuid()));
 
     private sealed class TestLocalPathProvider(string appData) : ILocalPathProvider
     {

--- a/tests/PatrimonioTech.Infra.Tests/Credentials/v1/FileUserCredentialRepositoryTests.cs
+++ b/tests/PatrimonioTech.Infra.Tests/Credentials/v1/FileUserCredentialRepositoryTests.cs
@@ -1,0 +1,109 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using PatrimonioTech.App.SelfApplication;
+using PatrimonioTech.Domain.Credentials;
+using PatrimonioTech.Domain.Credentials.Actions.AddUser;
+using PatrimonioTech.Domain.Credentials.Services;
+using PatrimonioTech.Infra.Credentials.Services;
+
+namespace PatrimonioTech.Infra.Tests.Credentials.v1;
+
+public sealed class FileUserCredentialRepositoryTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly FileUserCredentialRepository _sut;
+
+    public FileUserCredentialRepositoryTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+
+        _sut = new FileUserCredentialRepository(
+            Options.Create(new FileUserCredentialOptions()),
+            NullLogger<FileUserCredentialRepository>.Instance,
+            new TestLocalPathProvider(_tempDir));
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    public async Task GetAll_WhenFileDoesNotExist_ReturnsEmptyList()
+    {
+        var result = await _sut.GetAll(CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Add_WithNewCredential_ReturnsOk()
+    {
+        var result = await _sut.Add(MakeCredential("alice"), CancellationToken.None);
+
+        result.Should().BeOk();
+    }
+
+    [Fact]
+    public async Task Add_WithNewCredential_CanBeRetrievedByGetAll()
+    {
+        await _sut.Add(MakeCredential("alice"), CancellationToken.None);
+
+        var credentials = await _sut.GetAll(CancellationToken.None);
+
+        credentials.Should().HaveCount(1);
+        credentials[0].Name.Should().Be("alice");
+    }
+
+    [Fact]
+    public async Task Add_WithMultipleCredentials_AllCanBeRetrievedByGetAll()
+    {
+        await _sut.Add(MakeCredential("alice"), CancellationToken.None);
+        await _sut.Add(MakeCredential("bob"), CancellationToken.None);
+
+        var credentials = await _sut.GetAll(CancellationToken.None);
+
+        credentials.Should().HaveCount(2);
+        credentials.Select(c => c.Name).Should().BeEquivalentTo(["alice", "bob"]);
+    }
+
+    [Fact]
+    public async Task Add_WithDuplicateNameSameCase_ReturnsNameAlreadyExists()
+    {
+        await _sut.Add(MakeCredential("alice"), CancellationToken.None);
+
+        var result = await _sut.Add(MakeCredential("alice"), CancellationToken.None);
+
+        result.Should().BeErr().Should().Be(UserCredentialAddError.NameAlreadyExists);
+    }
+
+    [Fact]
+    public async Task Add_WithDuplicateNameDifferentCase_ReturnsNameAlreadyExists()
+    {
+        await _sut.Add(MakeCredential("alice"), CancellationToken.None);
+
+        var result = await _sut.Add(MakeCredential("ALICE"), CancellationToken.None);
+
+        result.Should().BeErr().Should().Be(UserCredentialAddError.NameAlreadyExists);
+    }
+
+    [Fact]
+    public async Task Add_WithDuplicateName_DoesNotAddNewEntry()
+    {
+        await _sut.Add(MakeCredential("alice"), CancellationToken.None);
+        await _sut.Add(MakeCredential("ALICE"), CancellationToken.None);
+
+        var credentials = await _sut.GetAll(CancellationToken.None);
+
+        credentials.Should().HaveCount(1);
+    }
+
+    private static UserCredential MakeCredential(string name) =>
+        UserCredential.Create(
+            new UserCredentialAdded(name, "$pbkdf2-sha512$i=100000,l=512$salt$key", Guid.NewGuid()));
+
+    private sealed class TestLocalPathProvider(string appData) : ILocalPathProvider
+    {
+        public string AppData => appData;
+        public void Initialize() { }
+    }
+}

--- a/tests/PatrimonioTech.Infra.Tests/Credentials/v1/Pbkdf2KeyDerivationTests.cs
+++ b/tests/PatrimonioTech.Infra.Tests/Credentials/v1/Pbkdf2KeyDerivationTests.cs
@@ -9,7 +9,7 @@ namespace PatrimonioTech.Infra.Tests.Credentials.v1;
 
 public class Pbkdf2KeyDerivationTests(ITestOutputHelper outputHelper)
 {
-    private readonly Pbkdf2KeyDerivation _keyDerivation = new(NullLogger<Pbkdf2KeyDerivation>.Instance);
+    private readonly Pbkdf2KeyDerivation _keyDerivation = new(NullLogger<Pbkdf2KeyDerivation>.Instance, new Pbkdf2PhcStringParser());
 
     [Theory]
     [InlineData("password")]

--- a/tests/PatrimonioTech.Infra.Tests/Credentials/v1/Pbkdf2KeyDerivationTests.cs
+++ b/tests/PatrimonioTech.Infra.Tests/Credentials/v1/Pbkdf2KeyDerivationTests.cs
@@ -1,9 +1,8 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using PatrimonioTech.Domain.Credentials;
 using PatrimonioTech.Domain.Credentials.Services;
 using PatrimonioTech.Infra.Credentials.Services;
-using PatrimonioTech.Infra.Tests.Common;
 using Xunit.Abstractions;
 
 namespace PatrimonioTech.Infra.Tests.Credentials.v1;
@@ -12,104 +11,60 @@ public class Pbkdf2KeyDerivationTests(ITestOutputHelper outputHelper)
 {
     private readonly Pbkdf2KeyDerivation _keyDerivation = new(NullLogger<Pbkdf2KeyDerivation>.Instance);
 
-    public static TheoryData<string, int, int> ValidInputs =>
-        (from p in new[] { "password", "Ovyr/X3uT6$>}ZM/(o'O'.37*O$*=nHn{8khQ_o6n}?|~}ITH<" }
-            from k in new[] { 128, 256, 512, 1024 }
-            from i in new[] { 1000, 10_000, 100_000 }
-            select (p, k, i))
-        .ToTheoryData();
-
     [Theory]
-    [MemberData(nameof(ValidInputs))]
-    public void CreateKey_WithValidInput_ReturnsSaltAndEncryptedKey(string password, int keySize, int iterations)
+    [InlineData("password")]
+    [InlineData("Ovyr/X3uT6$>}ZM/(o'O'.37*O$*=nHn{8khQ_o6n}?|~}ITH<")]
+    public void CreateKey_WithValidPassword_ReturnsPhcString(string password)
     {
-        //Act
-        var result = from p in Password.Create(password)
-            select _keyDerivation.CreateKey(p, keySize, iterations);
+        var p = Password.Create(password).Unwrap();
 
-        // Assert
-        var (salt, encryptedKey) = result.Should().BeOk();
+        var result = _keyDerivation.CreateKey(p);
 
-        salt.Should().NotBeEmpty();
-        encryptedKey.Should().NotBeEmpty();
+        var phcString = result.Should().BeOk();
+        phcString.Value.Should().StartWith("$pbkdf2-sha512$");
 
-        outputHelper.WriteLine("Salt: {0}", salt);
-        outputHelper.WriteLine("Encrypted key: {0}", encryptedKey);
+        outputHelper.WriteLine("PHC: {0}", phcString.Value);
     }
 
     [Theory]
-    [MemberData(nameof(ValidInputs))]
-    public void TryGetKey_WithValidInput_ReturnsKey(string password, int keySize, int iterations)
+    [InlineData("password")]
+    [InlineData("Ovyr/X3uT6$>}ZM/(o'O'.37*O$*=nHn{8khQ_o6n}?|~}ITH<")]
+    public void TryGetKey_WithValidPasswordAndPhcString_ReturnsKey(string password)
     {
-        // Arrange
-        var (salt, encryptedKey) = (from p in Password.Create(password)
-                select _keyDerivation.CreateKey(p, keySize, iterations))
-            .Unwrap();
+        var p = Password.Create(password).Unwrap();
+        var phcString = _keyDerivation.CreateKey(p).Unwrap();
 
-        // Act
-        var result1 = _keyDerivation.TryGetKey(password, salt, encryptedKey, keySize, iterations);
-        var result2 = _keyDerivation.TryGetKey(password, salt, encryptedKey, keySize, iterations);
+        var result1 = _keyDerivation.TryGetKey(password, phcString.Value);
+        var result2 = _keyDerivation.TryGetKey(password, phcString.Value);
 
-        // Assert
         result1.Should().BeOk();
         result1.Unwrap().Should().NotBeEmpty();
         result2.Unwrap().Should().Be(result1.Unwrap());
 
-        outputHelper.WriteLine("Salt: {0}", salt);
-        outputHelper.WriteLine("Encrypted key: {0}", encryptedKey);
+        outputHelper.WriteLine("PHC: {0}", phcString.Value);
         outputHelper.WriteLine("Key: {0}", result1.Unwrap());
     }
 
     [Theory]
-    [MemberData(nameof(ValidInputs))]
-    public void TryGetKey_WithInvalidSalt_ReturnsFailure(string password, int keySize, int iterations)
+    [InlineData("password")]
+    [InlineData("Ovyr/X3uT6$>}ZM/(o'O'.37*O$*=nHn{8khQ_o6n}?|~}ITH<")]
+    public void TryGetKey_WithInvalidPassword_ReturnsInvalidPassword(string password)
     {
-        // Arrange
-        const string salt = "invalid salt";
-        const string encryptedKey = "encryptedKey";
+        var p = Password.Create(password).Unwrap();
+        var phcString = _keyDerivation.CreateKey(p).Unwrap();
 
-        // Act
-        var result = _keyDerivation.TryGetKey(password, salt, encryptedKey, keySize, iterations);
+        var result1 = _keyDerivation.TryGetKey(password[..^2], phcString.Value);
+        var result2 = _keyDerivation.TryGetKey(password + password, phcString.Value);
 
-        // Assert
-        result.Should().BeErr()
-            .Should().Be(GetKeyError.InvalidSalt);
+        result1.Should().BeErr().Should().Be(GetKeyError.InvalidPassword);
+        result2.Should().BeErr().Should().Be(GetKeyError.InvalidPassword);
     }
 
-    [Theory]
-    [MemberData(nameof(ValidInputs))]
-    public void TryGetKey_WithInvalidEncryptedKey_ReturnsFailure(string password, int keySize, int iterations)
+    [Fact]
+    public void TryGetKey_WithMalformedPhcString_ReturnsInvalidPassword()
     {
-        // Arrange
-        var (salt, encryptedKey) = (from p in Password.Create(password)
-                select _keyDerivation.CreateKey(p, keySize, iterations))
-            .Unwrap();
+        var result = _keyDerivation.TryGetKey("password", "not-a-valid-phc-string");
 
-        // Act
-        var result = _keyDerivation.TryGetKey(password, salt, encryptedKey[..5], keySize, iterations);
-
-        // Assert
-        result.Should().BeErr()
-            .Should().Be(GetKeyError.InvalidEncryptedKey);
-    }
-
-    [Theory]
-    [MemberData(nameof(ValidInputs))]
-    public void TryGetKey_WithInvalidPassword_ReturnsFailure(string password, int keySize, int iterations)
-    {
-        // Arrange
-        var (salt, encryptedKey) = (from p in Password.Create(password)
-                select _keyDerivation.CreateKey(p, keySize, iterations))
-            .Unwrap();
-
-        // Act
-        var result1 = _keyDerivation.TryGetKey(password[..^2], salt, encryptedKey, keySize, iterations);
-        var result2 = _keyDerivation.TryGetKey(password + password, salt, encryptedKey, keySize, iterations);
-
-        // Assert
-        result1.Should().BeErr()
-            .Should().Be(GetKeyError.InvalidPassword);
-        result2.Should().BeErr()
-            .Should().Be(GetKeyError.InvalidPassword);
+        result.Should().BeErr().Should().Be(GetKeyError.InvalidPassword);
     }
 }

--- a/tests/PatrimonioTech.Infra.Tests/Credentials/v1/Pbkdf2KeyDerivationTests.cs
+++ b/tests/PatrimonioTech.Infra.Tests/Credentials/v1/Pbkdf2KeyDerivationTests.cs
@@ -21,7 +21,7 @@ public class Pbkdf2KeyDerivationTests(ITestOutputHelper outputHelper)
         var result = _keyDerivation.CreateKey(p);
 
         var phcString = result.Should().BeOk();
-        phcString.Value.Should().StartWith("$pbkdf2-sha512$");
+        phcString.Value.Should().StartWith("$pbkdf2-sha512-aes256cbc$");
 
         outputHelper.WriteLine("PHC: {0}", phcString.Value);
     }
@@ -61,10 +61,10 @@ public class Pbkdf2KeyDerivationTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public void TryGetKey_WithMalformedPhcString_ReturnsInvalidPassword()
+    public void TryGetKey_WithMalformedPhcString_ReturnsInvalidHash()
     {
         var result = _keyDerivation.TryGetKey("password", "not-a-valid-phc-string");
 
-        result.Should().BeErr().Should().Be(GetKeyError.InvalidPassword);
+        result.Should().BeErr().Should().Be(GetKeyError.InvalidHash);
     }
 }

--- a/tests/PatrimonioTech.Infra.Tests/Database/LiteDbDatabaseAdminTests.cs
+++ b/tests/PatrimonioTech.Infra.Tests/Database/LiteDbDatabaseAdminTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using LiteDB;
+using PatrimonioTech.App.SelfApplication;
+using PatrimonioTech.Infra.Database;
+
+namespace PatrimonioTech.Infra.Tests.Database;
+
+public sealed class LiteDbDatabaseAdminTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly LiteDbDatabaseAdmin _sut;
+
+    public LiteDbDatabaseAdminTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+
+        _sut = new LiteDbDatabaseAdmin(new TestLocalPathProvider(_tempDir), new BsonMapper());
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    public void CreateDatabase_WithValidInputs_ReturnsOk()
+    {
+        var result = _sut.CreateDatabase(Guid.NewGuid(), "testpassword123");
+
+        result.Should().BeOk();
+    }
+
+    [Fact]
+    public void CreateDatabase_WithValidInputs_CreatesFileAtExpectedPath()
+    {
+        var dbId = Guid.NewGuid();
+
+        _sut.CreateDatabase(dbId, "testpassword123");
+
+        var expectedPath = Path.Combine(_tempDir, $"{dbId:N}.db");
+        File.Exists(expectedPath).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CreateDatabase_WithValidInputs_DatabaseIsAccessibleWithCorrectPassword()
+    {
+        var dbId = Guid.NewGuid();
+        const string password = "testpassword123";
+
+        _sut.CreateDatabase(dbId, password);
+
+        var filePath = Path.Combine(_tempDir, $"{dbId:N}.db");
+        var connectionString = new ConnectionString { Filename = filePath, Password = password };
+        var act = () =>
+        {
+            using var db = new LiteDatabase(connectionString, new BsonMapper());
+            db.Checkpoint();
+        };
+        act.Should().NotThrow();
+    }
+
+    private sealed class TestLocalPathProvider(string appData) : ILocalPathProvider
+    {
+        public string AppData => appData;
+        public void Initialize() { }
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce `IPhcString` (Domain) as an opaque interface for password hashes, eliminating raw `Salt`/`Key`/`KeySize`/`Iterations` fields from the domain model
- Add `Pbkdf2PhcString` (Infra) encoding PBKDF2-SHA512 parameters and an AES-CBC encrypted database key as `$pbkdf2-sha512$i={iter},l={bits}${salt}${encryptedKey}`
- Simplify `IKeyDerivation` to `CreateKey(Password) → IPhcString` and `TryGetKey(password, passwordHash) → string`; replace `GetKeyError.InvalidSalt`/`InvalidEncryptedKey` with `InvalidPassword`
- Implement atomic writes in `FileUserCredentialRepository` via temp file + `File.Replace`/`File.Move`
- Update all tests (Domain, App, Infra) to the new API; add `FileUserCredentialRepositoryTests` and `LiteDbDatabaseAdminTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)